### PR TITLE
open ports to browse smb

### DIFF
--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -15,8 +15,12 @@ By default, it will log into the primary user on the first chroot found.
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
 # Forward ports needed to browse smb shares
-if test -n "$(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')"; then
-	iptables -I INPUT 1 -p udp --source $(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')/255.255.255.0 --dport 1025:65535 -j ACCEPT
+MYIP=$(ip route get 1 | awk -F 'src ' '{ split($2,a," ");print a[1];exit}')
+
+if test -n $MYIP; then
+	iptables -I INPUT 1 -p udp \
+	--source $MYIP/255.255.255.0 \
+	--dport 1025:65535 -j ACCEPT
 fi
 
 exec sh -e "`dirname "\`readlink -f -- "$0"\`"`/enter-chroot" -t kodi "$@" "" \

--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -17,7 +17,7 @@ Options are directly passed to enter-chroot; run enter-chroot to list them."
 # Forward ports needed to browse smb shares
 MYIP=$(ip route get 1 | awk -F 'src ' '{ split($2,a," ");print a[1];exit}')
 
-if test -n $MYIP; then
+if test $MYIP; then
 	iptables -I INPUT 1 -p udp \
 	--source $MYIP/255.255.255.0 \
 	--dport 1025:65535 -j ACCEPT

--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -14,5 +14,10 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
+# Forward ports needed to browse smb shares
+if test -n "$(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')"; then
+	iptables -I INPUT 1 -p udp --source $(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')/255.255.255.0 --dport 1025:65535 -j ACCEPT
+fi
+
 exec sh -e "`dirname "\`readlink -f -- "$0"\`"`/enter-chroot" -t kodi "$@" "" \
     exec croutonpowerd -i xinit /usr/bin/kodi --standalone

--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -17,9 +17,9 @@ Options are directly passed to enter-chroot; run enter-chroot to list them."
 # Forward ports needed to browse smb shares
 MYIP=$(ip route get 1 | awk -F 'src ' '{ split($2,a," ");print a[1];exit}')
 
-if test $MYIP; then
+if [ -n "$MYIP" ]; then
 	iptables -I INPUT 1 -p udp \
-	--source $MYIP/255.255.255.0 \
+	--source "$MYIP"/255.255.255.0 \
 	--dport 1025:65535 -j ACCEPT
 fi
 

--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -18,9 +18,9 @@ Options are directly passed to enter-chroot; run enter-chroot to list them."
 MYIP=$(ip route get 1 | awk -F 'src ' '{ split($2,a," ");print a[1];exit}')
 
 if [ -n "$MYIP" ]; then
-	iptables -I INPUT 1 -p udp \
-	--source "$MYIP"/255.255.255.0 \
-	--dport 1025:65535 -j ACCEPT
+    iptables -I INPUT 1 -p udp \
+        --source "$MYIP"/255.255.255.0 \
+        --dport 1025:65535 -j ACCEPT
 fi
 
 exec sh -e "`dirname "\`readlink -f -- "$0"\`"`/enter-chroot" -t kodi "$@" "" \


### PR DESCRIPTION
browsing smb/samba shares requires having ports 1025 - 65535 open.
this patch grabs the ip address from wlan0 and opens the ports when the source ip is within the local subnet.